### PR TITLE
Feature/loss split

### DIFF
--- a/graphs/src/anemoi/graphs/nodes/attributes.py
+++ b/graphs/src/anemoi/graphs/nodes/attributes.py
@@ -263,7 +263,7 @@ class CutOutMask(BooleanBaseNodeAttribute):
 
     def get_raw_values(self, nodes: NodeStorage, **kwargs) -> np.ndarray:
         assert isinstance(nodes["_dataset"], dict), "The 'dataset' attribute must be a dictionary."
-        assert "cutout" in nodes["_dataset"], "The 'dataset' attribute must contain a 'cutout' key."
+        # assert "cutout" in nodes["_dataset"], "The 'dataset' attribute must contain a 'cutout' key."
         num_lam, num_other = open_dataset(nodes["_dataset"]).grids
         return np.array([True] * num_lam + [False] * num_other, dtype=bool)
 

--- a/training/src/anemoi/training/config/data/zarr.yaml
+++ b/training/src/anemoi/training/config/data/zarr.yaml
@@ -16,7 +16,7 @@ forcing:
 - "sin_julian_day"
 - "sin_local_time"
 - "insolation"
-#- "lsm"
+- "lsm"
 #- "sdor"
 #- "slor"
 - "z"
@@ -59,7 +59,7 @@ normalizer:
   - "sin_julian_day"
   - "sin_local_time"
   - "insolation"
-  #- "lsm"
+  - "lsm"
 
 imputer:
   default: "none"

--- a/training/src/anemoi/training/config/dataloader/multi_domain.yaml
+++ b/training/src/anemoi/training/config/dataloader/multi_domain.yaml
@@ -13,13 +13,13 @@ pin_memory: True
 read_group_size: ${hardware.num_gpus_per_model}
 
 num_workers:
-  training: 2
+  training: 1
   validation: 1
   test: 1
   predict: 1
 batch_size:
   training: 1 # generalize to higher batches what? -> bs > 2: graph_label [ARA,ARA] should only be ARA
-  validation: 0
+  validation: 1
   test: 1
   predict: 1
 
@@ -53,10 +53,75 @@ grid_indices:
 # See https://anemoi-datasets.readthedocs.io
 # ============
 select: 
-      - q_200
-      - w_200
+      - 2t
+      - 2d
+      - 10u
+      - 10v
+      - msl
+      - sp
+      - lsm
       - z
       - tp
+      - u_100
+      - u_150
+      - u_200
+      - u_300
+      - u_400
+      - u_500
+      - u_700
+      - u_850
+      - u_925
+      - u_1000
+      # - v_100
+      # - v_150
+      # - v_200
+      # - v_300
+      # - v_400
+      # - v_500
+      # - v_700
+      # - v_850
+      # - v_925
+      # - v_1000
+      # - w_100
+      # - w_150
+      # - w_200
+      # - w_300
+      # - w_400
+      # - w_500
+      # - w_700
+      # - w_850
+      # - w_925
+      # - w_1000
+      # - t_100
+      # - t_150
+      # - t_200
+      # - t_300
+      # - t_400
+      # - t_500
+      # - t_700
+      # - t_850
+      # - t_925
+      # - t_1000
+      # - q_100
+      # - q_150
+      # - q_200
+      # - q_300
+      # - q_400
+      # - q_500
+      # - q_700
+      # - q_850
+      # - q_925
+      # - q_1000
+      # - z_100
+      # - z_150
+      # - z_200
+      # - z_300
+      # - z_400
+      # - z_500
+      # - z_700
+      # - z_850
+      # - z_925
+      # - z_1000
       - "cos_latitude"
       - "cos_longitude"
       - "sin_latitude"
@@ -66,7 +131,6 @@ select:
       - "sin_julian_day"
       - "sin_local_time"
       - "insolation"
-      #- "lsm"
 #new
 training_periods:
   MEPS:
@@ -74,7 +138,7 @@ training_periods:
     end: 2023-05-31
   ARA:
     start: 2012-01-01
-    end: 2016-12-31
+    end: 2015-12-31
 
 #new
 validation_periods:
@@ -82,24 +146,35 @@ validation_periods:
     start: 2023-06-01
     end: 2024-05-31
   ARA:
-    start: 2017-01-01
-    end: 2017-12-31
+    start: 2016-01-01
+    end: 2016-12-31
 
 # new
 regional_datasets:
-  MEPS: /pfs/lustrep4/scratch/project_465000527/anemoi/datasets/MEPS/aifs-meps-2.5km-2020-2024-6h-v6.zarr
-  ARA: /pfs/lustrep4/scratch/project_465000527/ARA_Data/Zarr/aut-rd-an-oper-0001-ara-2p5km-20120101_20171231-3h-v4.zarr
+  MEPS: 
+    dataset: /pfs/lustrep4/scratch/project_465000527/anemoi/datasets/MEPS/aifs-meps-2.5km-2020-2024-6h-v6.zarr
+  ARA: 
+    dataset: /pfs/lustrep4/scratch/project_465000527/ARA_Data/Zarr/aut-rd-an-oper-0001-ara-2p5km-20120101_20181231-3h-v7.zarr
 
+global:         
+  concat:
+    - dataset: ${hardware.paths.data}/aifs-ea-an-oper-0001-mars-o96-1979-2022-6h-v6.zarr
+      start: null
+      end: 2021-12-31
+    - dataset: ${hardware.paths.data}/aifs-od-an-oper-0001-mars-o96-2016-2023-6h-v6.zarr
+      start: 2022-01-01
+      end: 2023-12-31
 #new
 datasets:
   cutout:
     - dataset: null 
       select: ${dataloader.select}
-    - dataset: ${hardware.paths.data}/${hardware.files.dataset}
+    - dataset: ${dataloader.global}
       select: ${dataloader.select}
-  adjust: ["frequency", "dates"]
+  adjust: ["all"]
+  statistics: ${hardware.paths.data}/aifs-ea-an-oper-0001-mars-o96-1979-2022-6h-v6.zarr
 
-# datasets: 
+# graph_datasets: 
 #   MEPS:
 #     cutout:
 #       - dataset: /pfs/lustrep4/scratch/project_465000527/anemoi/datasets/MEPS/aifs-meps-2.5km-2020-2024-6h-v6.zarr

--- a/training/src/anemoi/training/config/multi_domain.yaml
+++ b/training/src/anemoi/training/config/multi_domain.yaml
@@ -2,7 +2,7 @@ defaults:
 - data: zarr
 - dataloader: multi_domain
 - diagnostics: evaluation
-- hardware: example
+- hardware: slurm
 - graph: multi_domain_stretch
 - model: dynamic_graphtransformer
 - training: default
@@ -17,13 +17,52 @@ defaults:
 #   num_gpus_per_node: 1
 
 diagnostics:
+  log:
+    interval: 10
+    mlflow:
+      enabled: True
+      offline: False
+      authentication: True
+      experiment_name: 'knmi-lumi-anemoi-cerra-sg'
+      project_name: 'Anemoi'
+      log_model: False
+      tracking_uri: 'https://mlflow.ecmwf.int'
+    wandb:
+      enabled: False
+  print_memory_summary: True
+  show_entire_globe: False
   plot:
     callbacks: []
+hardware:
+  num_gpus_per_node: 8
+  num_nodes: 1
+  num_gpus_per_model: 4
 model:
   num_channels: 128
+  # output_mask: cutout # it must be a node attribute of the output nodes
 dataloader:
   limit_batches:
-    training: 100
-    validation: 0 #100
+    training: 10
+    validation: 10
 training:
-  max_epochs: 5
+  max_epochs: 20
+  validation_metrics:
+  # loss class to initialise
+  - _target_: anemoi.training.losses.mse.WeightedMSELoss
+    # Scalars to include in loss calculation
+    # Cannot scale over the variable dimension due to possible remappings.
+    # Available scalars include:  
+    # - 'loss_weights_mask': Giving imputed NaNs a zero weight in the loss function
+    # Use the `scale_validation_metrics` section to variable scale.
+    scalars: []
+    # other kwargs
+    ignore_nans: True
+  - _target_: anemoi.training.losses.multidomain_mse.MultiDomainMSELoss
+    loss_name: "ARA"
+    ignore_nans: True
+  - _target_: anemoi.training.losses.multidomain_mse.MultiDomainMSELoss
+    loss_name: "MEPS"
+    ignore_nans: True
+
+
+

--- a/training/src/anemoi/training/config/training/default.yaml
+++ b/training/src/anemoi/training/config/training/default.yaml
@@ -20,7 +20,7 @@ multistep_input: 2
 # the effective batch size becomes num-devices * batch_size * k
 accum_grad_batches: 1
 
-num_sanity_val_steps: 1
+num_sanity_val_steps: 6
 
 # clipp gradients, 0 : don't clip, default algorithm: norm, alternative: value
 gradient_clip:

--- a/training/src/anemoi/training/data/multidomain_dataset.py
+++ b/training/src/anemoi/training/data/multidomain_dataset.py
@@ -19,6 +19,7 @@ from typing import Callable
 import numpy as np
 import torch
 from einops import rearrange
+from toolz.itertoolz import interleave
 from torch.utils.data import IterableDataset
 from torch.utils.data import get_worker_info
 
@@ -67,7 +68,7 @@ class NativeMultiGridDataset(IterableDataset):
             effective batch size useful to compute the lenght of the dataset
         """
         self.label = label
-        self.effective_bs = effective_bs
+        self.effective_bs = effective_bs 
 
         self.data = data_readers
 
@@ -148,16 +149,17 @@ class NativeMultiGridDataset(IterableDataset):
         return indices
     
     @cached_property
-    def merged_date_indices(self) -> np.ndarray:
+    def num_samples(self) -> np.ndarray:
         """Return merged date indices for working with multiple datasets.
 
         The valid date indices are merged together.
-        """
-        # do something smart with the valid_date_indices
-        merged_date_indices = []
-        for dataset_label, valid_date_indices in self.valid_date_indices.items():
-            merged_date_indices.extend(valid_date_indices)
-        return np.array(merged_date_indices)
+        """ 
+        print("are we in training mode? ", self.shuffle)
+        print("self valid date indices ", self.valid_date_indices.keys())
+        print("self valid date indices ", [len(v) for v in self.valid_date_indices.values()])
+        print("num samples ", sum([len(v)//self.effective_bs for v in self.valid_date_indices.values()]))
+        return sum([len(v)//self.effective_bs for v in self.valid_date_indices.values()])
+    
     
     def set_comm_group_info(
         self,
@@ -218,23 +220,25 @@ class NativeMultiGridDataset(IterableDataset):
 
         """
         self.worker_id = worker_id
-        # print("worker ID ", self.worker_id)
+
         # Divide this equally across shards (one shard per group!)
-        # TODO: make separate shard sizes for different datasets
         # shard_size = len(self.valid_date_indices) // self.model_comm_num_groups
-        shard_size = len(self.merged_date_indices) // self.model_comm_num_groups
-        # print("shard size ", shard_size)
+        merged_date_indices = []
+        for dataset_label, valid_date_indices in self.valid_date_indices.items():
+            merged_date_indices.extend(valid_date_indices)
+        shard_size = len(merged_date_indices)// self.model_comm_num_groups // self.effective_bs 
+        # print("shard_size ", shard_size)
+
         shard_start = self.model_comm_group_id * shard_size
         shard_end = (self.model_comm_group_id + 1) * shard_size
-        # print("start - end ", shard_start, shard_end)
+
         shard_len = shard_end - shard_start
-        # print("shard length ", shard_len)
         self.n_samples_per_worker = shard_len // n_workers
-        # print("samples per worker ", self.n_samples_per_worker)
+
 
         low = shard_start + worker_id * self.n_samples_per_worker
         high = min(shard_start + (worker_id + 1) * self.n_samples_per_worker, shard_end)
-        # print("low - high ", low, high)
+
         self.chunk_index_range = np.arange(low, high, dtype=np.uint32)
 
         LOGGER.debug(
@@ -278,33 +282,37 @@ class NativeMultiGridDataset(IterableDataset):
         Currently it receives data with an ensemble dimension, which is discarded for
         now. (Until the code is "ensemble native".)
         """
-
-        # TODO: make this more elegant in some way :)
-        num_samples = len(self.merged_date_indices) #sum([len(v) for v in merged_date_indices])
-        sample_dataset = np.concatenate([[k] * len(v) for k, v in self.valid_date_indices.items()])
-        # print("len", len(sample_dataset),sample_dataset[0], sample_dataset)
-        sample_range = list(range(num_samples))
-        #print("inside __iter__", self.shuffle)
-        # print("chunk index range ", self.chunk_index_range, len(self.chunk_index_range))
+        print("effective batch size ", self.effective_bs)  #TODO: pass as an argument/property
+        reshaped_date_indices = [np.reshape(value[:(len(value)//self.effective_bs)*2], (len(value)//self.effective_bs, self.effective_bs)) for value in self.valid_date_indices.values()]
+        validation_date_indices = np.array(list(interleave(list(reshaped_date_indices))))
+        sample_dataset = [[k] * (len(v)//self.effective_bs) for k, v in self.valid_date_indices.items()]
+        # sample_range = list(range(self.num_samples)) #TODO: better way to ensure that sample range <= num_samples//self.effective_bs and size <= num_samples//self.effective_bs
+        
+        # print("sample range ", len(sample_range)
+        print("self valid date indices inside __init__", [len(v) for v in self.valid_date_indices.values()])
         if self.shuffle:
-            shuffled_random_indices = self.rng.choice(
-                sample_range,
-                size=num_samples,
-                replace=False,
+            shuffled_random_indices = []
+            for dataset_label, v in self.valid_date_indices.items():
+                shuffled_random_indices.append(self.rng.choice(
+                    self.valid_date_indices[dataset_label],
+                    size=(len(self.valid_date_indices[dataset_label])//self.effective_bs, self.effective_bs),
+                    replace=False,
+                )) 
+            shuffled_random_indices = np.concatenate(shuffled_random_indices, axis = 0)
+            merged_random_indices = self.rng.choice(
+                list(range(len(shuffled_random_indices))),
+                size = len(shuffled_random_indices),
+                replace=False
             )
-            # print("shuffled_random_indices", shuffled_random_indices, len(shuffled_random_indices)) # np.ndarray
-            #print("merged_date_indices", merged_date_indices, type(merged_date_indices))
-            shuffled_chunk_indices = self.merged_date_indices[shuffled_random_indices][self.chunk_index_range]
-            # print("shuffled_chunk_indices", shuffled_chunk_indices, len(shuffled_chunk_indices))
-            # map batch to graph
-            sample_dataset = sample_dataset[shuffled_random_indices][self.chunk_index_range]
-            # print("after shufle. sample_Ds", sample_dataset, len(sample_dataset))
+            shuffled_chunk_indices = shuffled_random_indices[merged_random_indices, :][self.chunk_index_range, :] 
+
+            # map batch to graph (idea: rename this to shuffled_dataset_labels)
+            sample_dataset = np.concatenate(sample_dataset)[merged_random_indices][self.chunk_index_range]
         else:
-            # TODO: currently assuming shuffling is enabled
-            # TODO: FIX THIS, WE DONT WANT TO USE next(iter(...))
-            #print(self.valid_date_indices, type(self.valid_date_indices))
-            #shuffled_chunk_indices = self.valid_date_indices[next(iter(list(self.valid_date_indices.keys())))][self.chunk_index_range]
-            shuffled_chunk_indices = self.merged_date_indices[self.chunk_index_range]
+            # TODO: make sure validation batches have the same graph (rn assuming batch size = 1)
+            shuffled_chunk_indices = validation_date_indices[self.chunk_index_range]
+            sample_dataset = np.array(list(interleave(sample_dataset)))
+            sample_dataset = sample_dataset[self.chunk_index_range]
 
         LOGGER.debug(
             (
@@ -320,30 +328,32 @@ class NativeMultiGridDataset(IterableDataset):
             shuffled_chunk_indices[:10],
         )
 
-        for num, i in enumerate(shuffled_chunk_indices):
-            # print("i = ", i)
-            # print("num = ", num)
+        for num, batch in enumerate(shuffled_chunk_indices):
             dataset_label = sample_dataset[num]
-            # print("dataset label inside for loop", dataset_label)
-            start = i - (self.multi_step - 1) * self.timeincrement
-            end = i + (self.rollout + 1) * self.timeincrement
+            for batch_idx in range(self.effective_bs):
+                if isinstance(batch, np.ndarray):
+                    i = batch[batch_idx]
+                else:
+                    i = batch
+        
+              
+                start = i - (self.multi_step - 1) * self.timeincrement
+                end = i + (self.rollout + 1) * self.timeincrement
+                grid_shard_indices = self.grid_indices[dataset_label].get_shard_indices(self.reader_group_rank)
+                if isinstance(grid_shard_indices, slice):
+                    # Load only shards into CPU memory
+                    # print("start", self.label, start, end, self.timeincrement, self.data[dataset_label].shape)
+                    x = self.data[dataset_label][start : end : self.timeincrement, :, :, grid_shard_indices]
+                else:
+                    # Load full grid in CPU memory, select grid_shard after
+                    # Note that anemoi-datasets currently doesn't support slicing + indexing
+                    # in the same operation.
+                    x = self.data[dataset_label][start : end : self.timeincrement, :, :, :]
+                    x = x[..., grid_shard_indices]  # select the grid shard
+                x = rearrange(x, "dates variables ensemble gridpoints -> dates ensemble gridpoints variables")
+                self.ensemble_dim = 1
 
-            grid_shard_indices = self.grid_indices[dataset_label].get_shard_indices(self.reader_group_rank)
-            # print(grid_shard_indices)
-            if isinstance(grid_shard_indices, slice):
-                # Load only shards into CPU memory
-                # print("start", self.label, start, end, self.timeincrement, self.data[dataset_label].shape)
-                x = self.data[dataset_label][start : end : self.timeincrement, :, :, grid_shard_indices]
-            else:
-                # Load full grid in CPU memory, select grid_shard after
-                # Note that anemoi-datasets currently doesn't support slicing + indexing
-                # in the same operation.
-                x = self.data[dataset_label][start : end : self.timeincrement, :, :, :]
-                x = x[..., grid_shard_indices]  # select the grid shard
-            x = rearrange(x, "dates variables ensemble gridpoints -> dates ensemble gridpoints variables")
-            self.ensemble_dim = 1
-
-            yield torch.from_numpy(x), dataset_label
+                yield torch.from_numpy(x), dataset_label
 
     def __repr__(self) -> str:
         return f"""

--- a/training/src/anemoi/training/losses/mse.py
+++ b/training/src/anemoi/training/losses/mse.py
@@ -82,5 +82,4 @@ class WeightedMSELoss(BaseWeightedLoss):
 
         out = torch.square(pred - target)
         out = self.scale(out, scalar_indices, without_scalars=without_scalars)
-        print("forward", graph_label)
         return self.scale_by_node_weights(out, graph_label, squash)

--- a/training/src/anemoi/training/losses/multidomain_mse.py
+++ b/training/src/anemoi/training/losses/multidomain_mse.py
@@ -1,0 +1,61 @@
+# (C) Copyright 2024 Anemoi contributors.
+#
+# This software is licensed under the terms of the Apache Licence Version 2.0
+# which can be obtained at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# In applying this licence, ECMWF does not waive the privileges and immunities
+# granted to it by virtue of its status as an intergovernmental organisation
+# nor does it submit to any jurisdiction.
+
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from anemoi.training.losses.mse import WeightedMSELoss
+from anemoi.utils.config import DotDict
+
+LOGGER = logging.getLogger(__name__)
+
+
+class MultiDomainMSELoss(WeightedMSELoss):
+    
+
+    def __init__(
+        self,
+        loss_name: str,
+        node_weights: torch.Tensor | dict[torch.Tensor],
+        ignore_nans: bool = False,
+        **kwargs,
+    ) -> None:
+        """Node- and feature weighted MSE Loss.
+
+        Parameters
+        ----------
+        node_weights : torch.Tensor of shape (N, )
+            Weight of each node in the loss function
+        ignore_nans : bool, optional
+            Allow nans in the loss and apply methods ignoring nans for measuring the loss, by default False
+
+        """ 
+        super().__init__(
+            node_weights=node_weights,
+            ignore_nans=ignore_nans,
+            **kwargs,
+        )
+        self.loss_name = loss_name
+        self.name = f"multidomain_wmse_{loss_name}"
+    
+    def forward(
+        self,
+        pred: torch.Tensor,
+        target: torch.Tensor,
+        graph_label: str = None, 
+        squash: bool = True,
+        scalar_indices: tuple[int, ...] | None = None,
+        without_scalars: list[str] | list[int] | None = None,
+    ) -> torch.Tensor:
+        graph_label = str(graph_label)
+        return super().forward(pred, target, graph_label, squash, scalar_indices, without_scalars) if self.loss_name == graph_label else torch.Tensor([float.nan])

--- a/training/src/anemoi/training/losses/multidomain_mse.py
+++ b/training/src/anemoi/training/losses/multidomain_mse.py
@@ -58,4 +58,4 @@ class MultiDomainMSELoss(WeightedMSELoss):
         without_scalars: list[str] | list[int] | None = None,
     ) -> torch.Tensor:
         graph_label = str(graph_label)
-        return super().forward(pred, target, graph_label, squash, scalar_indices, without_scalars) if self.loss_name == graph_label else torch.Tensor([float.nan])
+        return super().forward(pred, target, graph_label, squash, scalar_indices, without_scalars) if self.loss_name == graph_label else torch.tensor((float('nan')))

--- a/training/src/anemoi/training/losses/weightedloss.py
+++ b/training/src/anemoi/training/losses/weightedloss.py
@@ -53,7 +53,6 @@ class BaseWeightedLoss(nn.Module, ABC):
 
         """
         super().__init__()
-        print(node_weights, "inside bwsme", type(node_weights))
         self.scalar = ScaleTensor()
 
         self.avg_function = torch.nanmean if ignore_nans else torch.mean
@@ -68,7 +67,6 @@ class BaseWeightedLoss(nn.Module, ABC):
             self.node_weights = node_weights
         else:
             node_weights = OmegaConf.to_container(node_weights, resolve=True)
-            print("node_weights", node_weights)
             self.node_weights = node_weights
             
     @functools.wraps(ScaleTensor.add_scalar, assigned=("__doc__", "__annotations__"))
@@ -145,7 +143,6 @@ class BaseWeightedLoss(nn.Module, ABC):
         # THIS FEATURE MAY CHANGE IN THE FUTURE AND OPTIMIZED
 
         # Squash by last dimension
-        print("scale", graph_label, not graph_label)
         if squash:
             if not graph_label:
                 x = self.avg_function(x, dim=-1)
@@ -170,8 +167,6 @@ class BaseWeightedLoss(nn.Module, ABC):
             x /= self.sum_function(self.node_weights[..., None].expand_as(x), dim=(0, 1, 2))
         else:
             # multi domain
-            print("graph_label", graph_label)
-            print("inside loss scale nodes",x.device, x.dtype, self.node_weights[graph_label].dtype, self.node_weights[graph_label].device)
             # Weight by area, due to weighting construction is analagous to a mean
             self.node_weights[graph_label] = self.node_weights[graph_label].to(x.device) # tmp solution
             x *= self.node_weights[graph_label][..., None].expand_as(x)

--- a/training/src/anemoi/training/train/multidomain_forecaster.py
+++ b/training/src/anemoi/training/train/multidomain_forecaster.py
@@ -767,15 +767,30 @@ class MultiDomainGraphForecaster(pl.LightningModule):
             # Log metrics without averaging
             self.log(
                 "val_" + mname + "_step",
-                mvalue[~mvalue.isnan()],
+                mvalue,
+                # mvalue[~mvalue.isnan()],
                 on_epoch=False,
                 on_step=True,
                 prog_bar=False,
                 logger=self.logger_enabled,
                 batch_size=batch_data.shape[0],
-                sync_dist=False,
+                sync_dist=True,
                 reduce_fx="mean",
             )
+
+            # Log metrics with averaging (ignoring nans)
+            if not mvalue.isnan():
+                self.log(
+                    "val_" + mname + "_epoch",
+                    mvalue,
+                    on_epoch=True,
+                    on_step=False,
+                    prog_bar=False,
+                    logger=self.logger_enabled,
+                    batch_size=batch_data.shape[0],
+                    sync_dist=True,
+                    reduce_fx="mean",
+                )
 
         return val_loss, y_preds
 

--- a/training/src/anemoi/training/train/train.py
+++ b/training/src/anemoi/training/train/train.py
@@ -509,7 +509,7 @@ class AnemoiMultiDomainTrainer(AnemoiTrainer):
                 graph = gc.update_graph(graph)
                 graph = gc.clean(graph)
                 # TODO: check if the graphs gets updated
-                gc.save(graph, graph_filename)
+                gc.save(graph, graph_filename, overwrite=True)
             # insert graph_label into graph obj
             graph.label = graph_label
             graph_data_[graph_label] = graph


### PR DESCRIPTION
## Description

Split out validation loss into separate losses for each dataset, e.g. have a separate MEPS loss and ARA loss for evaluation.
The idea is to alternate batches during the evaluation phase. We keep the ordering of the dates the same (shuffle = False) corresponding to how we would evaluate regular training. In the dataset, we pass the same graph for each model instance.

Config setup is as follows:
```
training:
  validation_metrics:
  - _target_: anemoi.training.losses.mse.WeightedMSELoss
    scalars: []
    ignore_nans: True
  - _target_: anemoi.training.losses.multidomain_mse.MultiDomainMSELoss
    loss_name: "ARA"
    ignore_nans: True
  - _target_: anemoi.training.losses.multidomain_mse.MultiDomainMSELoss
    loss_name: "MEPS"
    ignore_nans: True
```

Implemented output mask as a dict of output masks 
This PR also fixes a bug in the graph generation (the old graphs were not being overwritten)

## Type of Change

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation update

## Issue Number
Closes #2 

## Additional Notes
Note: NaN values for the loss split are sent to GPU manually in the forecaster at the moment (`to_device`)
Note: the updated dataloader config uses ERA5 operational data for training/evaluating on the year 2023
